### PR TITLE
docs(setup): add dev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Download and install the file corresponding to your Operating System, from [that
 
 ### Dev Setup
 
-1. Run openwhyd locally following the install guide `https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md`
+1. Run openwhyd locally following the install guide [https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md](https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md)
 2. clone `https://github.com/openwhyd/openwhyd-electron` on your computer.
 3. Modify the `const URL_PREFIX` found in the file `src/main.js` from `https://openwhyd.org` to `http://localhost:8080`
 4. Now open a second terminal window and type the following commands

--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ Download and install the file corresponding to your Operating System, from [that
 ⭐️ Did it work for you? Please leave your feedback [on Github](https://github.com/openwhyd/openwhyd-electron/issues/6) or [on Facebook](https://www.messenger.com/t/openwhyd).
 
 🛠 Contributors are welcome! If you want to help, you can create [issues](https://github.com/openwhyd/openwhyd-electron/issues) for bugs you may find and/or improvement requests. If you want to contribute, check out our [backlog](https://github.com/openwhyd/openwhyd-electron/projects/1) and come say "hi" on one of the issues you'd be interested in contributing to.
+
+### Dev Setup
+
+1. Run openwhyd locally following the install guide `https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md`
+2. clone `https://github.com/openwhyd/openwhyd-electron` on your computer.
+3. Modify the `const URL_PREFIX` found in the file `src/main.js` from `https://openwhyd.org` to `http://localhost:8080`
+4. Now open a second terminal window and type the following commands
+
+```sh
+$ cd openwhyd-electron # Go into the repository
+$ npm install # Install dependencies
+$ npm start # The local electron app should pop open with Openwhyd's home page! 🎉
+```


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #27  .

## What does this PR do / solve?

Add documentation on how to run electron app locally.

## Overview of changes

I modified the README.md file with the following:

### Dev Setup

1. Run openwhyd locally following the install guide [https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md](https://github.com/openwhyd/openwhyd/blob/master/docs/INSTALL.md)
2. clone `https://github.com/openwhyd/openwhyd-electron` on your computer.
3. Modify the `const URL_PREFIX` found in the file `src/main.js` from `https://openwhyd.org` to `http://localhost:8080`
4. Now open a second terminal window and type the following commands

```sh
$ cd openwhyd-electron # Go into the repository
$ npm install # Install dependencies
$ npm start # The local electron app should pop open with Openwhyd's home page! 🎉
```


